### PR TITLE
fix: Update GEMINI_API_KEY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ A Next.js chat application that integrates with Google's Genkit AI for conversat
    ```
 
 2. Set up your Google AI API key:
-   - Make sure you have `GOOGLE_GENAI_API_KEY` environment variable set
+   - Make sure you have `GEMINI_API_KEY` environment variable set
    - Or create a `.env.local` file with:
      ```
-     GOOGLE_GENAI_API_KEY=your_api_key_here
+     GEMINI_API_KEY=your_api_key_here
      ```
 
 3. Run the development server:

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
The environment variable for the API key has been updated from GOOGLE_GENAI_API_KEY to GEMINI_API_KEY. 